### PR TITLE
windows: use taskkill to kill entire process tree

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ IS_WIN = os.name=='nt'
 IS_MAC = sys.platform=='darwin'
 
 from time import sleep, time
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen, PIPE, STDOUT, call, STARTUPINFO, STARTF_USESHOWWINDOW
 from threading import Thread, Lock
 from collections import namedtuple
 import json
@@ -388,8 +388,13 @@ class Terminal:
         if ch_out:
             ch_out.close()
         if self.p:
-            self.p.terminate()
-            self.p.wait()
+            if IS_WIN:
+                startupinfo = STARTUPINFO()
+                startupinfo.dwFlags |= STARTF_USESHOWWINDOW
+                call(['taskkill', '/F', '/T', '/PID',  str(self.p.pid)], startupinfo=startupinfo)
+            else:
+                self.p.terminate()
+                self.p.wait()
 
 
     def restart_shell(self):


### PR DESCRIPTION
without patch: 10 processes out of 15 is still alive after closing all 5 terminal tabs.
with patch: 0 processes out of 15 is alive. entire tree for every terminal is killed using "taskkill" windows command.

![image](https://user-images.githubusercontent.com/275333/169749477-72ad8d39-0276-4aca-9996-524563cd60e8.png)
![image](https://user-images.githubusercontent.com/275333/169750561-41c67c58-a2e4-44ec-a442-2557e5b3882a.png)
