### PR TITLE
fixed: empty bottom panel (when floating)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1288,6 +1288,8 @@ class Command:
             self.h_embed = None
 
         app_proc(PROC_BOTTOMPANEL_ADD_DIALOG, (self.title, h_embed, fn_icon))
+        if self.floating: # fixes empty bottom panel on start (when floating)
+            activate_bottompanel(self.termbar.get_active_sidebar())
 
         timer_proc(TIMER_START, self.timer_update, 200, tag='')
 


### PR DESCRIPTION
happens only on Cud start.

before:

![image](https://user-images.githubusercontent.com/275333/172453200-5d8fccd3-8167-4d41-b332-d9619de9050f.png)

after:

![image](https://user-images.githubusercontent.com/275333/172453318-d6dfe4de-fa18-4117-9def-77c919c00761.png)
